### PR TITLE
SkelVector fixes

### DIFF
--- a/pydart2/skel_vector.py
+++ b/pydart2/skel_vector.py
@@ -13,7 +13,7 @@ class SkelVector(np.ndarray):
     def to_index(self, key):
         if isinstance(key, int):
             if key < 0:
-                return len(self) - key
+                return len(self) + key
             else:
                 return key
         elif isinstance(key, str):

--- a/pydart2/skel_vector.py
+++ b/pydart2/skel_vector.py
@@ -55,3 +55,4 @@ class SkelVector(np.ndarray):
         if obj is None:
             return
         self.skel = getattr(obj, 'skel', None)
+        self.keys = getattr(obj, 'keys', None)


### PR DESCRIPTION
I ran into some bugs a while back when I was trying to run some of the examples. The indexing logic one is self-explanatory. Without the line adding in the "keys" attribute, trying to print a SkelVector will often result in an error